### PR TITLE
Update HOWTO.md

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -238,12 +238,11 @@ of 5 years. You may supply any information for your sign request to identify you
 They are not currently checked by the client except for the validity date.
 When asked for a challenge password just leave it empty and press enter.
     
-    $ cd ~/stratis/electrum-stratis-server
-    $ openssl genrsa -des3 -passout pass:x -out server.pass.key 4096
-    $ openssl rsa -passin pass:x -in server.pass.key -out server.key
+    $ cd ~/stratis/electrum-stratis-server                                  
+    $ openssl genrsa -aes256 -passout pass:stratis -out server.key 4096   //generate rsa key with ae256 4096-bit encryption
+    $ openssl rsa -passin pass:stratis -in server.key -out server.key     //strip key of password
     writing RSA key
-    $ rm server.pass.key
-    $ openssl req -new -key server.key -out server.csr
+    $ openssl req -new -key server.key -out server.csr                    //generate CSR
     ...
     Country Name (2 letter code) [AU]:US
     State or Province Name (full name) [Some-State]:California

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -248,7 +248,7 @@ When asked for a challenge password just leave it empty and press enter.
     State or Province Name (full name) [Some-State]:California
     Common Name (eg, YOUR name) []: electrum-server.tld
     ...
-    A challenge password []:
+    A challenge password []:                                             // Leave Password blank !
     ...
 
     $ openssl x509 -req -days 1825 -in server.csr -signkey electrum-stratis-server.key -out electrum-stratis-server.crt

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -237,8 +237,9 @@ Use the sample code below to create a self-signed cert with a recommended validi
 of 5 years. You may supply any information for your sign request to identify your server.
 They are not currently checked by the client except for the validity date.
 When asked for a challenge password just leave it empty and press enter.
-
-    $ openssl genrsa -des3 -passout pass:x -out server.pass.key 2048
+    
+    $ cd ~/stratis/electrum-stratis-server
+    $ openssl genrsa -des3 -passout pass:x -out server.pass.key 4096
     $ openssl rsa -passin pass:x -in server.pass.key -out server.key
     writing RSA key
     $ rm server.pass.key
@@ -251,7 +252,7 @@ When asked for a challenge password just leave it empty and press enter.
     A challenge password []:
     ...
 
-    $ openssl x509 -req -days 1825 -in server.csr -signkey server.key -out server.crt
+    $ openssl x509 -req -days 1825 -in server.csr -signkey electrum-stratis-server.key -out electrum-stratis-server.crt
 
 The server.crt file is your certificate suitable for the `ssl_certfile=` parameter and
 server.key corresponds to `ssl_keyfile=` in your Electrum server config.

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -239,7 +239,7 @@ They are not currently checked by the client except for the validity date.
 When asked for a challenge password just leave it empty and press enter.
     
     $ cd ~/stratis/electrum-stratis-server                                  
-    $ openssl genrsa -aes256 -passout pass:stratis -out server.key 4096   //generate rsa key with ae256 4096-bit encryption
+    $ openssl genrsa -aes256 -passout pass:stratis -out server.key 4096   //generate rsa key
     $ openssl rsa -passin pass:stratis -in server.key -out server.key     //strip key of password
     writing RSA key
     $ openssl req -new -key server.key -out server.csr                    //generate CSR


### PR DESCRIPTION
Modification on creating openssl self signed server certificate to generate RSA key in 4096 bits for improved defense against brute force attacks. Additionally, changed key/crt file names to identify with electrum-stratis-server in case the user creates them in a folder with other keys.