### PR TITLE
Update HOWTO.md

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -79,7 +79,7 @@ We will also use the `~/bin` directory to keep locally installed files
 (others might want to use `/usr/local/bin` instead). We will download source
 code files to the `~/src` directory.
 
-    $ sudo adduser stratis --disabled-password
+    $ sudo adduser --system --group --create-home --disabled-password stratis
     $ sudo apt-get install git
     $ sudo su - stratis
     $ mkdir ~/bin ~/src


### PR DESCRIPTION
For security reasons it's best to run the server with its own unprivileged user profile.  

(System users will be created with no aging information in /etc/shadow, and their numeric identifiers are chosen in the SYS_UID_MIN-SYS_UID_MAX range, defined in /etc/login.defs, instead of UID_MIN-UID_MAX (and their GID counterparts for the creation of groups). 

Placing the user in its own group resolves some security concerns of file access permissions.